### PR TITLE
Adjust URL in Readme instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ Launch a web server
 python3 -m http.server
 ````
 
-Then, browse to http://localhost:8000/src/implot_demo.html
+Then, browse to http://localhost:8000/build_emscripten/src/implot_demo.html
 
 ### Build instructions on desktop (linux, MacOS, Windows)
 


### PR DESCRIPTION
The built output sits in the `build_emscripten` directory, which should be part of the localhost URL for a seamless *getting started* experience (just ran into that).